### PR TITLE
Use go base image

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.22"
           cache: false
       - name: Checkout the code
         uses: actions/checkout@v3.2.0

--- a/docker-files/Dockerfile
+++ b/docker-files/Dockerfile
@@ -15,10 +15,10 @@
 #
 # Dockerfile to build CSI Metadata Retriever sidecar
 # some arguments that must be supplied
-ARG GOVERSION
+ARG GOIMAGE
 ARG BASEIMAGE
 # Stage to build the driver
-FROM golang:${GOVERSION} as builder
+FROM $GOIMAGE as builder
 
 RUN mkdir -p /go/src
 COPY ./ /go/src/

--- a/docker.mk
+++ b/docker.mk
@@ -22,13 +22,13 @@ docker: download-csm-common
 	$(eval include csm-common.mk)
 	echo "Building: $(REGISTRY)/$(IMAGENAME):v$(MAJOR).$(MINOR).$(PATCH) RELNOTE $(RELNOTE)"
 	echo "$(DOCKER_FILE)"
-	$(BUILDER) build -f $(DOCKER_FILE) -t "$(REGISTRY)/$(IMAGENAME):v$(MAJOR).$(MINOR).$(PATCH)$(RELNOTE)" --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) .
+	$(BUILDER) build -f $(DOCKER_FILE) -t "$(REGISTRY)/$(IMAGENAME):v$(MAJOR).$(MINOR).$(PATCH)$(RELNOTE)" --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) .
 
 docker-no-cache: download-csm-common
 	$(eval include csm-common.mk)
 	echo "Building: $(REGISTRY)/$(IMAGENAME):$(MAJOR).$(MINOR).$(PATCH) RELNOTE $(RELNOTE)"
 	echo "$(DOCKER_FILE) --no-cache"
-	$(BUILDER) build --no-cache --pull -f $(DOCKER_FILE) -t "$(REGISTRY)/$(IMAGENAME):v$(MAJOR).$(MINOR).$(PATCH)$(RELNOTE)" --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) .
+	$(BUILDER) build --no-cache --pull -f $(DOCKER_FILE) -t "$(REGISTRY)/$(IMAGENAME):v$(MAJOR).$(MINOR).$(PATCH)$(RELNOTE)" --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) .
 
 
 push:   

--- a/overrides.mk
+++ b/overrides.mk
@@ -18,14 +18,14 @@
 
 
 # DEFAULT values
-DEFAULT_GOVERSION="1.21"
+DEFAULT_GOIMAGE=$(shell sed -En 's/^go (.*)$$/\1/p' go.mod)
 DEFAULT_REGISTRY="dellemc"
 DEFAULT_IMAGENAME="csi-metadata-retriever"
 
 
-# set the GOVERSION if needed
-ifeq ($(GOVERSION),)
-export GOVERSION="$(DEFAULT_GOVERSION)"
+# set the GOIMAGE if needed
+ifeq ($(GOIMAGE),)
+export GOIMAGE="$(DEFAULT_GOIMAGE)"
 endif
 
 # set the REGISTRY if needed
@@ -67,8 +67,8 @@ overrides-help:
 	@echo
 	@echo "The following environment variables can be set to control the build"
 	@echo
-	@echo "GOVERSION   - The version of Go to build with, default is: $(DEFAULT_GOVERSION)"
-	@echo "              Current setting is: $(GOVERSION)"
+	@echo "GOIMAGE   - The version of Go to build with, default is: $(DEFAULT_GOIMAGE)"
+	@echo "              Current setting is: $(GOIMAGE)"
 	@echo "REGISTRY    - The registry to push images to, default is: $(DEFAULT_REGISTRY)"
 	@echo "              Current setting is: $(REGISTRY)"
 	@echo "IMAGENAME   - The image name to be built, defaut is: $(DEFAULT_IMAGENAME)"


### PR DESCRIPTION
# Description
Changes to point to Default go image version in common.mk file.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1098 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Image build:
![image](https://github.com/dell/csi-metadata-retriever/assets/92028646/d2a28a12-58f9-49eb-8c00-1f2789f84f41)

