### PR TITLE
Added IMAGETAG for image building

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -15,21 +15,25 @@
 -include vars.mk
 include overrides.mk
 
+ifeq ($(IMAGETAG),)
+IMAGETAG="v$(MAJOR).$(MINOR).$(PATCH)$(RELNOTE)"
+endif
+
 docker: download-csm-common
 	$(eval include csm-common.mk)
-	echo "Building: $(REGISTRY)/$(IMAGENAME):v$(MAJOR).$(MINOR).$(PATCH) RELNOTE $(RELNOTE)"
+	echo "Building: $(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"
 	echo "$(DOCKER_FILE)"
-	$(BUILDER) build --pull -f $(DOCKER_FILE) -t "$(REGISTRY)/$(IMAGENAME):v$(MAJOR).$(MINOR).$(PATCH)$(RELNOTE)" --build-arg BASEIMAGE=$(CSM_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) .
+	$(BUILDER) build --pull -f $(DOCKER_FILE) -t "$(REGISTRY)/$(IMAGENAME):$(IMAGETAG)" --build-arg BASEIMAGE=$(CSM_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) .
 
 docker-no-cache: download-csm-common
 	$(eval include csm-common.mk)
-	echo "Building: $(REGISTRY)/$(IMAGENAME):$(MAJOR).$(MINOR).$(PATCH) RELNOTE $(RELNOTE)"
+	echo "Building: $(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"
 	echo "$(DOCKER_FILE) --no-cache"
-	$(BUILDER) build --pull --no-cache --pull -f $(DOCKER_FILE) -t "$(REGISTRY)/$(IMAGENAME):v$(MAJOR).$(MINOR).$(PATCH)$(RELNOTE)" --build-arg BASEIMAGE=$(CSM_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) .
+	$(BUILDER) build --pull --no-cache --pull -f $(DOCKER_FILE) -t "$(REGISTRY)/$(IMAGENAME):$(IMAGETAG)" --build-arg BASEIMAGE=$(CSM_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) .
 
 push:
-	echo "Pushing MAJOR $(MAJOR) MINOR $(MINOR) PATCH $(PATCH) RELNOTE $(RELNOTE)"
-	$(BUILDER) push "$(REGISTRY)/$(IMAGENAME):v$(MAJOR).$(MINOR).$(PATCH)$(RELNOTE)"
+	echo "Pushing $(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"
+	$(BUILDER) push "$(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"
 
 download-csm-common:
 	curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk


### PR DESCRIPTION
# Description
Added IMAGETAG to the image building process for the TechOps pipeline. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] Backward compatibility is not broken

# How Has This Been Tested?

`export IMAGETAG='nightly'
`
```
[root@master-1-gMLffggcEYiL6 csi-metadata-retriever]# make docker
go generate .
make -f docker.mk DOCKER_FILE=docker-files/Dockerfile  docker
make[1]: Entering directory '/home/sl/csm/csi-metadata-retriever'
curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk
echo "Building: ""dellemc""/""csi-metadata-retriever"":nightly"
Building: dellemc/csi-metadata-retriever:nightly
echo "docker-files/Dockerfile"
docker-files/Dockerfile
podman build --pull -f docker-files/Dockerfile -t """dellemc""/""csi-metadata-retriever"":nightly" --build-arg BASEIMAGE=quay.io/dell/container-storage-modules/csm-base-image:nightly --build-arg GOIMAGE=golang:1.24 .
[1/2] STEP 1/5: FROM golang:1.24 AS builder
[1/2] STEP 2/5: RUN mkdir -p /go/src
.....
Successfully tagged localhost/dellemc/csi-metadata-retriever:nightly
b785abd98fd6e9fdd7006fc651b9a134f1de44dbd9c546a48b3418ab418a6efc
make[1]: Leaving directory '/home/sl/csm/csi-metadata-retriever'

[root@master-1-gMLffggcEYiL6 csi-metadata-retriever]# podman images
REPOSITORY                                                        TAG                    IMAGE ID      CREATED         SIZE
localhost/dellemc/csi-metadata-retriever                          nightly                b785abd98fd6  25 minutes ago  269 MB
```